### PR TITLE
Added github pages deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+dist: trusty
+sudo: required
+language: generic
+
+before_install:
+  - sudo apt-get -q update
+  - sudo apt-get install -y texlive-latex-extra texlive-math-extra mathpartir
+
+script:
+  - make docs
+
+deploy:
+  provider: pages
+  local_dir: ./docs
+  project_name: "Specification of Agda"
+  skip_cleanup: true
+  target_branch: gh-pages
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  on:
+    branch: master

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
 default :
 	make -C src
 
+docs : default clean
+	cp src/*.pdf docs/
+
+.PHONY: clean
+clean :
+	mkdir -p docs/
+	rm -f docs/*.pdf
+
 # EOF

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# agda-spec
+# agda-spec [![Build Status](https://travis-ci.org/agda/agda-spec.svg?branch=master)](https://travis-ci.org/agda/agda-spec)
 Specification of Agda.
+
+* [core-agda.pdf](http://agda.github.io/agda-spec/core-agda.pdf)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 default : core-agda.pdf
 
 %.pdf : %.tex
-	pdflatex $<
+	pdflatex -interaction nonstopmode -halt-on-error -file-line-error $<
 
 # EOF


### PR DESCRIPTION
Steps to enable deployment:
1. Enable Travis for `agda-spec`, probably at https://travis-ci.org/profile/agda
2. Create a new _personal access token_ with _public_repo scope_ at https://github.com/settings/tokens:
    ![https-github com-settings-tokens-new](https://cloud.githubusercontent.com/assets/6059032/26093081/94a4ff4e-3a14-11e7-99a3-ef512b368a6f.png)
3. Add the token to travis's environment at https://travis-ci.org/agda/agda-spec/settings
![screencapture-travis-ci-org-schnittstabil-agda-spec-settings-1494917597641](https://cloud.githubusercontent.com/assets/6059032/26094269/91be9696-3a19-11e7-8ea2-6b747b013d11.png)

4. Enable github pages https://github.com/agda/agda-spec/settings:
![screencapture-github-schnittstabil-agda-spec-settings-1494918383281](https://cloud.githubusercontent.com/assets/6059032/26093998/6a36afce-3a18-11e7-8a28-77593324843e.png)